### PR TITLE
feat: add web data services

### DIFF
--- a/lib/data/services/data_deletion_service_web.dart
+++ b/lib/data/services/data_deletion_service_web.dart
@@ -1,0 +1,353 @@
+import 'package:logger/logger.dart';
+import 'package:universal_html/html.dart' as html;
+
+import '../repositories/user_repository.dart';
+import '../repositories/workout_repository.dart';
+import '../repositories/exercise_repository.dart';
+import '../repositories/pr_repository.dart';
+import '../repositories/template_repository.dart';
+import '../repositories/notification_repository.dart';
+import '../repositories/streak_repository.dart';
+import '../repositories/notification_preferences_repository.dart';
+
+/// Web implementation of [DataDeletionService]
+class DataDeletionService {
+  final UserRepository _userRepository;
+  final WorkoutSessionRepository _workoutRepository;
+  final ExerciseRepository _exerciseRepository;
+  final PRRepository _prRepository;
+  final TemplateRepository _templateRepository;
+  final NotificationRepository _notificationRepository;
+  final StreakRepository _streakRepository;
+  final NotificationPreferencesRepository _notificationPreferencesRepository;
+  final Logger _logger = Logger();
+
+  DataDeletionService({
+    required UserRepository userRepository,
+    required WorkoutSessionRepository workoutRepository,
+    required ExerciseRepository exerciseRepository,
+    required PRRepository prRepository,
+    required TemplateRepository templateRepository,
+    required NotificationRepository notificationRepository,
+    required StreakRepository streakRepository,
+    required NotificationPreferencesRepository notificationPreferencesRepository,
+  })  : _userRepository = userRepository,
+        _workoutRepository = workoutRepository,
+        _exerciseRepository = exerciseRepository,
+        _prRepository = prRepository,
+        _templateRepository = templateRepository,
+        _notificationRepository = notificationRepository,
+        _streakRepository = streakRepository,
+        _notificationPreferencesRepository = notificationPreferencesRepository;
+
+  /// Deletes all local user data (web version)
+  Future<DeletionResult> deleteLocalUserData(
+    String userId, {
+    Function(double progress, String status)? onProgress,
+  }) async {
+    try {
+      _logger.i('Starting local data deletion for user: $userId');
+      int deletedRecords = 0;
+      onProgress?.call(0.0, 'Initializing deletion...');
+
+      final user = await _userRepository.findById(userId);
+      if (user == null) {
+        throw DeletionException('User not found: $userId');
+      }
+
+      onProgress?.call(0.1, 'Deleting workout sessions...');
+      final workoutSessions = await _workoutRepository.findByUserId(userId);
+      for (final session in workoutSessions) {
+        await _workoutRepository.deleteById(session.id);
+        deletedRecords++;
+      }
+
+      onProgress?.call(0.3, 'Deleting personal records...');
+      final prRecords = await _prRepository.findByUserId(userId);
+      for (final pr in prRecords) {
+        await _prRepository.deleteById(pr.id);
+        deletedRecords++;
+      }
+
+      onProgress?.call(0.5, 'Deleting workout templates...');
+      final templates = await _templateRepository.findByUserId(userId);
+      for (final template in templates) {
+        await _templateRepository.deleteById(template.id);
+        deletedRecords++;
+      }
+
+      onProgress?.call(0.7, 'Deleting notifications...');
+      final notifications = await _notificationRepository.findByUserId(userId);
+      for (final notification in notifications) {
+        await _notificationRepository.deleteById(notification.id);
+        deletedRecords++;
+      }
+
+      onProgress?.call(0.8, 'Deleting streak records...');
+      final streakRecords = await _streakRepository.findByUserId(userId);
+      for (final streak in streakRecords) {
+        await _streakRepository.deleteById(streak.id);
+        deletedRecords++;
+      }
+
+      onProgress?.call(0.9, 'Deleting notification preferences...');
+      try {
+        final preferences =
+            await _notificationPreferencesRepository.findByUserId(userId);
+        if (preferences != null) {
+          await _notificationPreferencesRepository.deleteById(preferences.id);
+          deletedRecords++;
+        }
+      } catch (e) {
+        _logger.w('Failed to delete notification preferences: $e');
+      }
+
+      onProgress?.call(0.95, 'Deleting user profile...');
+      await _userRepository.deleteById(userId);
+      deletedRecords++;
+
+      onProgress?.call(1.0, 'Deletion completed');
+      _logger.i('Local data deletion completed successfully for user: $userId');
+
+      return DeletionResult(
+        success: true,
+        deletedRecords: deletedRecords,
+        deletionType: DeletionType.local,
+      );
+    } catch (e, stackTrace) {
+      _logger.e('Local data deletion failed for user: $userId',
+          error: e, stackTrace: stackTrace);
+      return DeletionResult(
+        success: false,
+        error: e.toString(),
+        deletionType: DeletionType.local,
+      );
+    }
+  }
+
+  /// Deletes all application data (complete reset)
+  Future<DeletionResult> deleteAllApplicationData({
+    Function(double progress, String status)? onProgress,
+  }) async {
+    try {
+      _logger.i('Starting complete application data deletion');
+      onProgress?.call(0.0, 'Initializing complete deletion...');
+
+      onProgress?.call(0.5, 'Clearing storage...');
+      await _clearApplicationCache();
+
+      onProgress?.call(1.0, 'Complete deletion finished');
+      _logger.i('Complete application data deletion completed successfully');
+
+      return DeletionResult(
+        success: true,
+        deletedRecords: -1,
+        deletionType: DeletionType.complete,
+      );
+    } catch (e, stackTrace) {
+      _logger.e('Complete application data deletion failed',
+          error: e, stackTrace: stackTrace);
+      return DeletionResult(
+        success: false,
+        error: e.toString(),
+        deletionType: DeletionType.complete,
+      );
+    }
+  }
+
+  /// Requests server-side data deletion (simulated)
+  Future<DeletionResult> requestServerDataDeletion(String userId) async {
+    try {
+      _logger.i('Requesting server data deletion for user: $userId');
+      await Future.delayed(const Duration(seconds: 2));
+      _logger.i('Server data deletion requested successfully for user: $userId');
+      return DeletionResult(
+        success: true,
+        deletionType: DeletionType.server,
+        message:
+            'Server data deletion has been requested. You will receive a confirmation email within 24 hours.',
+      );
+    } catch (e, stackTrace) {
+      _logger.e('Server data deletion request failed for user: $userId',
+          error: e, stackTrace: stackTrace);
+      return DeletionResult(
+        success: false,
+        error: e.toString(),
+        deletionType: DeletionType.server,
+      );
+    }
+  }
+
+  /// Performs complete account deletion (local + server)
+  Future<DeletionResult> deleteCompleteAccount(
+    String userId, {
+    Function(double progress, String status)? onProgress,
+  }) async {
+    try {
+      _logger.i('Starting complete account deletion for user: $userId');
+      onProgress?.call(0.0, 'Deleting local data...');
+      final localResult = await deleteLocalUserData(
+        userId,
+        onProgress: (progress, status) => onProgress?.call(progress * 0.7, status),
+      );
+
+      if (!localResult.success) {
+        return localResult.copyWith(deletionType: DeletionType.complete);
+      }
+
+      onProgress?.call(0.7, 'Requesting server data deletion...');
+      final serverResult = await requestServerDataDeletion(userId);
+
+      onProgress?.call(1.0, 'Account deletion completed');
+      _logger.i('Complete account deletion completed for user: $userId');
+
+      return DeletionResult(
+        success: localResult.success && serverResult.success,
+        deletedRecords: localResult.deletedRecords,
+        deletionType: DeletionType.complete,
+        message: serverResult.message,
+        error: serverResult.success ? null : serverResult.error,
+      );
+    } catch (e, stackTrace) {
+      _logger.e('Complete account deletion failed for user: $userId',
+          error: e, stackTrace: stackTrace);
+      return DeletionResult(
+        success: false,
+        error: e.toString(),
+        deletionType: DeletionType.complete,
+      );
+    }
+  }
+
+  Future<void> _clearApplicationCache() async {
+    try {
+      html.window.localStorage.clear();
+    } catch (e) {
+      _logger.w('Failed to clear application cache: $e');
+    }
+  }
+
+  Future<void> _cleanupOrphanedData() async {
+    // No-op for web implementation
+  }
+
+  Future<void> _deleteDatabaseFile() async {
+    // No-op for web implementation
+  }
+
+  Future<DeletionInfo> getDeletionInfo(String userId) async {
+    try {
+      int totalRecords = 0;
+      final details = <String, int>{};
+
+      final user = await _userRepository.findById(userId);
+      if (user != null) {
+        totalRecords += 1;
+        details['User Profile'] = 1;
+      }
+
+      final workoutSessions = await _workoutRepository.findByUserId(userId);
+      totalRecords += workoutSessions.length;
+      details['Workout Sessions'] = workoutSessions.length;
+
+      final totalSets =
+          workoutSessions.fold(0, (sum, session) => sum + session.sets.length);
+      details['Workout Sets'] = totalSets;
+
+      final prRecords = await _prRepository.findByUserId(userId);
+      totalRecords += prRecords.length;
+      details['Personal Records'] = prRecords.length;
+
+      final templates = await _templateRepository.findByUserId(userId);
+      totalRecords += templates.length;
+      details['Workout Templates'] = templates.length;
+
+      final notifications = await _notificationRepository.findByUserId(userId);
+      totalRecords += notifications.length;
+      details['Notifications'] = notifications.length;
+
+      final streakRecords = await _streakRepository.findByUserId(userId);
+      totalRecords += streakRecords.length;
+      details['Streak Records'] = streakRecords.length;
+
+      return DeletionInfo(
+        totalRecords: totalRecords,
+        details: details,
+        estimatedTime: _estimateDeletionTime(totalRecords),
+      );
+    } catch (e) {
+      _logger.e('Failed to get deletion info for user: $userId', error: e);
+      rethrow;
+    }
+  }
+
+  Duration _estimateDeletionTime(int recordCount) {
+    final milliseconds = (recordCount * 10) + 1000;
+    return Duration(milliseconds: milliseconds);
+  }
+}
+
+class DeletionResult {
+  final bool success;
+  final int? deletedRecords;
+  final DeletionType deletionType;
+  final String? message;
+  final String? error;
+
+  DeletionResult({
+    required this.success,
+    this.deletedRecords,
+    required this.deletionType,
+    this.message,
+    this.error,
+  });
+
+  DeletionResult copyWith({
+    bool? success,
+    int? deletedRecords,
+    DeletionType? deletionType,
+    String? message,
+    String? error,
+  }) {
+    return DeletionResult(
+      success: success ?? this.success,
+      deletedRecords: deletedRecords ?? this.deletedRecords,
+      deletionType: deletionType ?? this.deletionType,
+      message: message ?? this.message,
+      error: error ?? this.error,
+    );
+  }
+}
+
+class DeletionInfo {
+  final int totalRecords;
+  final Map<String, int> details;
+  final Duration estimatedTime;
+
+  DeletionInfo({
+    required this.totalRecords,
+    required this.details,
+    required this.estimatedTime,
+  });
+
+  String get formattedEstimatedTime {
+    if (estimatedTime.inMinutes > 0) {
+      return '${estimatedTime.inMinutes} minute(s)';
+    } else {
+      return '${estimatedTime.inSeconds} second(s)';
+    }
+  }
+}
+
+enum DeletionType {
+  local,
+  server,
+  complete,
+}
+
+class DeletionException implements Exception {
+  final String message;
+  DeletionException(this.message);
+  @override
+  String toString() => 'DeletionException: $message';
+}

--- a/lib/data/services/data_export_service_web.dart
+++ b/lib/data/services/data_export_service_web.dart
@@ -1,0 +1,318 @@
+import 'dart:convert';
+import 'package:universal_html/html.dart' as html;
+import 'package:logger/logger.dart';
+
+import '../../domain/entities/user.dart';
+import '../../domain/entities/workout_session.dart';
+import '../../domain/entities/exercise.dart';
+import '../../domain/entities/pr_record.dart';
+import '../../domain/entities/template.dart';
+import '../../domain/entities/notification.dart';
+import '../../domain/entities/streak_record.dart';
+import '../repositories/user_repository.dart';
+import '../repositories/workout_repository.dart';
+import '../repositories/exercise_repository.dart';
+import '../repositories/pr_repository.dart';
+import '../repositories/template_repository.dart';
+import '../repositories/notification_repository.dart';
+import '../repositories/streak_repository.dart';
+
+/// Web implementation of [DataExportService]
+class DataExportService {
+  final UserRepository _userRepository;
+  final WorkoutSessionRepository _workoutRepository;
+  final ExerciseRepository _exerciseRepository;
+  final PRRepository _prRepository;
+  final TemplateRepository _templateRepository;
+  final NotificationRepository _notificationRepository;
+  final StreakRepository _streakRepository;
+  final Logger _logger = Logger();
+
+  DataExportService({
+    required UserRepository userRepository,
+    required WorkoutSessionRepository workoutRepository,
+    required ExerciseRepository exerciseRepository,
+    required PRRepository prRepository,
+    required TemplateRepository templateRepository,
+    required NotificationRepository notificationRepository,
+    required StreakRepository streakRepository,
+  })  : _userRepository = userRepository,
+        _workoutRepository = workoutRepository,
+        _exerciseRepository = exerciseRepository,
+        _prRepository = prRepository,
+        _templateRepository = templateRepository,
+        _notificationRepository = notificationRepository,
+        _streakRepository = streakRepository;
+
+  /// Exports all user data to JSON format and triggers browser download
+  Future<ExportResult> exportUserData(
+    String userId, {
+    Function(double progress, String status)? onProgress,
+  }) async {
+    try {
+      _logger.i('Starting data export for user: $userId');
+
+      final exportData = <String, dynamic>{};
+      final exportMetadata = {
+        'exportedAt': DateTime.now().toIso8601String(),
+        'exportVersion': '1.0.0',
+        'userId': userId,
+      };
+
+      onProgress?.call(0.0, 'Initializing export...');
+
+      onProgress?.call(0.1, 'Exporting user profile...');
+      final user = await _userRepository.findById(userId);
+      if (user == null) {
+        throw ExportException('User not found: $userId');
+      }
+      exportData['user'] = user.toJson();
+
+      onProgress?.call(0.2, 'Exporting workout sessions...');
+      final workoutSessions = await _workoutRepository.findByUserId(userId);
+      exportData['workoutSessions'] =
+          workoutSessions.map((session) => session.toJson()).toList();
+
+      onProgress?.call(0.4, 'Exporting exercises...');
+      final exerciseIds = workoutSessions
+          .expand((session) => session.sets)
+          .map((set) => set.exerciseId)
+          .toSet();
+      final exercises = <Exercise>[];
+      for (final exerciseId in exerciseIds) {
+        final exercise = await _exerciseRepository.findById(exerciseId);
+        if (exercise != null) {
+          exercises.add(exercise);
+        }
+      }
+      exportData['exercises'] =
+          exercises.map((exercise) => exercise.toJson()).toList();
+
+      onProgress?.call(0.6, 'Exporting personal records...');
+      final prRecords = await _prRepository.findByUserId(userId);
+      exportData['prRecords'] = prRecords.map((pr) => pr.toJson()).toList();
+
+      onProgress?.call(0.7, 'Exporting workout templates...');
+      final templates = await _templateRepository.findByUserId(userId);
+      exportData['templates'] = templates.map((t) => t.toJson()).toList();
+
+      onProgress?.call(0.8, 'Exporting notifications...');
+      final notifications = await _notificationRepository.findByUserId(userId);
+      exportData['notifications'] =
+          notifications.map((n) => n.toJson()).toList();
+
+      onProgress?.call(0.9, 'Exporting streak records...');
+      final streakRecords = await _streakRepository.findByUserId(userId);
+      exportData['streakRecords'] =
+          streakRecords.map((s) => s.toJson()).toList();
+
+      final finalExportData = {
+        'metadata': exportMetadata,
+        'data': exportData,
+      };
+
+      onProgress?.call(0.95, 'Generating JSON file...');
+      final jsonString = const JsonEncoder.withIndent('  ').convert(finalExportData);
+
+      onProgress?.call(1.0, 'Preparing download...');
+      final url = _triggerDownload(userId, jsonString);
+
+      _logger.i('Data export completed successfully for user: $userId');
+
+      return ExportResult(
+        success: true,
+        filePath: url,
+        fileSize: jsonString.length,
+        recordCount: _calculateRecordCount(exportData),
+      );
+    } catch (e, stackTrace) {
+      _logger.e('Data export failed for user: $userId',
+          error: e, stackTrace: stackTrace);
+      return ExportResult(
+        success: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Creates a download link for the exported data
+  String _triggerDownload(String userId, String jsonData) {
+    final bytes = utf8.encode(jsonData);
+    final blob = html.Blob([bytes], 'application/json');
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final fileName = 'cycleavatar_export_${userId}_$timestamp.json';
+    final anchor = html.AnchorElement(href: url)
+      ..download = fileName
+      ..style.display = 'none';
+    html.document.body?.append(anchor);
+    anchor.click();
+    anchor.remove();
+    return url;
+  }
+
+  int _calculateRecordCount(Map<String, dynamic> exportData) {
+    int count = 0;
+    if (exportData['user'] != null) count += 1;
+    if (exportData['workoutSessions'] != null) {
+      count += (exportData['workoutSessions'] as List).length;
+    }
+    if (exportData['exercises'] != null) {
+      count += (exportData['exercises'] as List).length;
+    }
+    if (exportData['prRecords'] != null) {
+      count += (exportData['prRecords'] as List).length;
+    }
+    if (exportData['templates'] != null) {
+      count += (exportData['templates'] as List).length;
+    }
+    if (exportData['notifications'] != null) {
+      count += (exportData['notifications'] as List).length;
+    }
+    if (exportData['streakRecords'] != null) {
+      count += (exportData['streakRecords'] as List).length;
+    }
+    return count;
+  }
+
+  /// Shares the exported file by triggering another download
+  Future<void> shareExportFile(String fileUrl) async {
+    final anchor = html.AnchorElement(href: fileUrl)
+      ..download = ''
+      ..style.display = 'none';
+    html.document.body?.append(anchor);
+    anchor.click();
+    anchor.remove();
+  }
+
+  Future<DataSizeInfo> getUserDataSize(String userId) async {
+    try {
+      int totalRecords = 0;
+      int totalSize = 0;
+
+      final user = await _userRepository.findById(userId);
+      if (user != null) {
+        totalRecords += 1;
+        totalSize += user.toJson().toString().length;
+      }
+
+      final workoutSessions = await _workoutRepository.findByUserId(userId);
+      totalRecords += workoutSessions.length;
+      totalSize += workoutSessions.fold<int>(
+          0, (sum, session) => sum + session.toJson().toString().length);
+
+      final prRecords = await _prRepository.findByUserId(userId);
+      totalRecords += prRecords.length;
+      totalSize += prRecords.fold(
+          0, (sum, pr) => sum + pr.toJson().toString().length);
+
+      final templates = await _templateRepository.findByUserId(userId);
+      totalRecords += templates.length;
+      totalSize += templates.fold(
+          0, (sum, template) => sum + template.toJson().toString().length);
+
+      final notifications = await _notificationRepository.findByUserId(userId);
+      totalRecords += notifications.length;
+      totalSize += notifications.fold(0,
+          (sum, notification) => sum + notification.toJson().toString().length);
+
+      final streakRecords = await _streakRepository.findByUserId(userId);
+      totalRecords += streakRecords.length;
+      totalSize += streakRecords.fold(
+          0, (sum, streak) => sum + streak.toJson().toString().length);
+
+      return DataSizeInfo(
+        totalRecords: totalRecords,
+        approximateSize: totalSize,
+        workoutSessions: workoutSessions.length,
+        prRecords: prRecords.length,
+        templates: templates.length,
+        notifications: notifications.length,
+        streakRecords: streakRecords.length,
+      );
+    } catch (e) {
+      _logger.e('Failed to calculate user data size for user: $userId', error: e);
+      rethrow;
+    }
+  }
+
+  Future<bool> validateExportFile(String fileUrl) async {
+    try {
+      final content = await html.HttpRequest.getString(fileUrl);
+      final data = jsonDecode(content) as Map<String, dynamic>;
+      if (!data.containsKey('metadata') || !data.containsKey('data')) {
+        return false;
+      }
+      final metadata = data['metadata'] as Map<String, dynamic>;
+      if (!metadata.containsKey('exportedAt') ||
+          !metadata.containsKey('exportVersion') ||
+          !metadata.containsKey('userId')) {
+        return false;
+      }
+      return true;
+    } catch (e) {
+      _logger.e('Export file validation failed: $fileUrl', error: e);
+      return false;
+    }
+  }
+}
+
+class ExportResult {
+  final bool success;
+  final String? filePath;
+  final int? fileSize;
+  final int? recordCount;
+  final String? error;
+
+  ExportResult({
+    required this.success,
+    this.filePath,
+    this.fileSize,
+    this.recordCount,
+    this.error,
+  });
+
+  String get formattedFileSize {
+    if (fileSize == null) return 'Unknown';
+    if (fileSize! < 1024) return '${fileSize!} B';
+    if (fileSize! < 1024 * 1024) {
+      return '${(fileSize! / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(fileSize! / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}
+
+class DataSizeInfo {
+  final int totalRecords;
+  final int approximateSize;
+  final int workoutSessions;
+  final int prRecords;
+  final int templates;
+  final int notifications;
+  final int streakRecords;
+
+  DataSizeInfo({
+    required this.totalRecords,
+    required this.approximateSize,
+    required this.workoutSessions,
+    required this.prRecords,
+    required this.templates,
+    required this.notifications,
+    required this.streakRecords,
+  });
+
+  String get formattedSize {
+    if (approximateSize < 1024) return '${approximateSize} B';
+    if (approximateSize < 1024 * 1024) {
+      return '${(approximateSize / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(approximateSize / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}
+
+class ExportException implements Exception {
+  final String message;
+  ExportException(this.message);
+  @override
+  String toString() => 'ExportException: $message';
+}

--- a/lib/presentation/providers/data_management_provider.dart
+++ b/lib/presentation/providers/data_management_provider.dart
@@ -1,8 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:logger/logger.dart';
 
-import '../../data/services/data_export_service.dart';
-import '../../data/services/data_deletion_service.dart';
+import '../../data/services/data_export_service.dart'
+    if (dart.library.html) '../../data/services/data_export_service_web.dart';
+import '../../data/services/data_deletion_service.dart'
+    if (dart.library.html) '../../data/services/data_deletion_service_web.dart';
 import '../../core/providers/providers.dart';
 
 /// Provider for data export service
@@ -20,17 +23,32 @@ final dataExportServiceProvider = Provider<DataExportService>((ref) {
 
 /// Provider for data deletion service
 final dataDeletionServiceProvider = Provider<DataDeletionService>((ref) {
-  return DataDeletionService(
-    userRepository: ref.read(userRepositoryProvider),
-    workoutRepository: ref.read(workoutRepositoryProvider),
-    exerciseRepository: ref.read(exerciseRepositoryProvider),
-    prRepository: ref.read(prRepositoryProvider),
-    templateRepository: ref.read(templateRepositoryProvider),
-    notificationRepository: ref.read(notificationRepositoryProvider),
-    streakRepository: ref.read(streakRepositoryProvider),
-    notificationPreferencesRepository: ref.read(notificationPreferencesRepositoryProvider),
-    databaseHelper: ref.read(databaseHelperProvider),
-  );
+  if (kIsWeb) {
+    return DataDeletionService(
+      userRepository: ref.read(userRepositoryProvider),
+      workoutRepository: ref.read(workoutRepositoryProvider),
+      exerciseRepository: ref.read(exerciseRepositoryProvider),
+      prRepository: ref.read(prRepositoryProvider),
+      templateRepository: ref.read(templateRepositoryProvider),
+      notificationRepository: ref.read(notificationRepositoryProvider),
+      streakRepository: ref.read(streakRepositoryProvider),
+      notificationPreferencesRepository:
+          ref.read(notificationPreferencesRepositoryProvider),
+    );
+  } else {
+    return DataDeletionService(
+      userRepository: ref.read(userRepositoryProvider),
+      workoutRepository: ref.read(workoutRepositoryProvider),
+      exerciseRepository: ref.read(exerciseRepositoryProvider),
+      prRepository: ref.read(prRepositoryProvider),
+      templateRepository: ref.read(templateRepositoryProvider),
+      notificationRepository: ref.read(notificationRepositoryProvider),
+      streakRepository: ref.read(streakRepositoryProvider),
+      notificationPreferencesRepository:
+          ref.read(notificationPreferencesRepositoryProvider),
+      databaseHelper: ref.read(databaseHelperProvider),
+    );
+  }
 });
 
 /// State for data management operations

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   # File Operations
   path_provider: ^2.1.1
   share_plus: ^7.2.1
+  universal_html: ^2.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add web implementations for exporting and deleting data
- conditionally load web or mobile data services
- add universal_html dependency

## Testing
- `dart format lib/data/services/data_export_service_web.dart lib/data/services/data_deletion_service_web.dart lib/presentation/providers/data_management_provider.dart pubspec.yaml` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac62122ee4832fb8a232174bf77f9d